### PR TITLE
Create models for authorization API

### DIFF
--- a/src/AccountsService/AccountsService.csproj
+++ b/src/AccountsService/AccountsService.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/src/AccountsService/Constants/Auth/AccountsPolicies.cs
+++ b/src/AccountsService/Constants/Auth/AccountsPolicies.cs
@@ -1,0 +1,14 @@
+﻿namespace AccountsService.Auth
+{
+    /// <summary>
+    /// Provides identity policies name. Should be used instead of direct role's-name specification
+    /// </summary>
+    public class AccountsPolicies
+    {
+        // Will provide access for all roles, such as admin, user, etc
+        public const string DefaultRights = "DefaultRights";    
+
+        // Will provide access for such roles as admin
+        public const string ElevatedRights = "ElevatedRights";  
+    }
+}

--- a/src/AccountsService/Constants/Auth/AccountsRoles.cs
+++ b/src/AccountsService/Constants/Auth/AccountsRoles.cs
@@ -1,0 +1,8 @@
+﻿namespace AccountsService.Auth
+{
+    public class AccountsRoles
+    {
+        public const string DefaultUser = "DefaultUser";
+        public const string Administrator = "Administrator";
+    }
+}

--- a/src/AccountsService/Infrastructure/Context/AccountsServiceContext.cs
+++ b/src/AccountsService/Infrastructure/Context/AccountsServiceContext.cs
@@ -43,4 +43,3 @@ namespace AccountsService.Infrastructure.Context
         }
     }
 }
-}

--- a/src/AccountsService/Infrastructure/Context/AccountsServiceContext.cs
+++ b/src/AccountsService/Infrastructure/Context/AccountsServiceContext.cs
@@ -1,0 +1,46 @@
+﻿using AccountsService.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace AccountsService.Infrastructure.Context
+{
+    public class AccountsServiceContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
+    {
+        public AccountsServiceContext(DbContextOptions<AccountsServiceContext> opt) : base(opt) 
+        {
+            Database.EnsureCreated();
+        }
+
+        public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            var entries = ChangeTracker
+                .Entries()
+                .Where(e =>
+                    e.State == EntityState.Modified || e.State == EntityState.Added)
+                .Where(e =>
+                    e.Properties.Where(p =>
+                        p.Metadata.Name == "UpdatedAt" || p.Metadata.Name == "CreatedAt").Any());
+
+            if (!entries.Any())
+                return await base.SaveChangesAsync(cancellationToken);
+
+            foreach (var entityEntry in entries)
+            {
+                switch (entityEntry.State)
+                {
+                    case EntityState.Modified:
+                        entityEntry.Property("UpdatedAt").CurrentValue = DateTime.UtcNow;
+                        break;
+
+                    case EntityState.Added:
+                        entityEntry.Property("CreatedAt").CurrentValue = DateTime.UtcNow;
+                        break;
+                }
+            }
+
+            return await base.SaveChangesAsync(cancellationToken);
+        }
+    }
+}
+}

--- a/src/AccountsService/Models/User.cs
+++ b/src/AccountsService/Models/User.cs
@@ -4,8 +4,8 @@ namespace AccountsService.Models
 {
     public class User : IdentityUser<Guid>
     {
-        public DateTime CreatedOn { get; private set; } = DateTime.UtcNow;
-        public DateTime LastUpdated { get; private set; } = DateTime.UtcNow;
+        public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; private set; } = DateTime.UtcNow;
         public bool IsDeleted { get; set; }
     }
 }

--- a/src/AccountsService/Models/User.cs
+++ b/src/AccountsService/Models/User.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace AccountsService.Models
+{
+    public class User : IdentityUser<Guid>
+    {
+        public DateTime CreatedOn { get; private set; } = DateTime.UtcNow;
+        public DateTime LastUpdated { get; private set; } = DateTime.UtcNow;
+        public bool IsDeleted { get; set; }
+    }
+}

--- a/src/AccountsService/Program.cs
+++ b/src/AccountsService/Program.cs
@@ -1,4 +1,30 @@
+using AccountsService.Auth;
+using AccountsService.Infrastructure.Context;
+using AccountsService.Models;
+using Microsoft.AspNetCore.Identity;
+
 var builder = WebApplication.CreateBuilder(args);
+
+//Identity
+builder.Services.AddIdentity<User, IdentityRole<Guid>>(options =>
+{
+    options.Password.RequiredLength = 5;
+    options.Password.RequireNonAlphanumeric = false;
+    options.Password.RequireLowercase = false;
+    options.Password.RequireUppercase = false;
+    options.Password.RequireDigit = true;
+    options.User.RequireUniqueEmail = true;
+}).AddEntityFrameworkStores<AccountsServiceContext>();
+
+//Authorization
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy(AccountsPolicies.DefaultRights, policy =>
+        policy.RequireRole(AccountsRoles.DefaultUser, AccountsRoles.Administrator));
+
+    options.AddPolicy(AccountsPolicies.ElevatedRights, policy =>
+        policy.RequireRole(AccountsRoles.Administrator));
+});
 
 builder.Services.AddControllers();
 


### PR DESCRIPTION
### What

API should store accounts
Each account has:
- Login/Username
- Password
- Role
API has two Roles: Admin and User;

### How

Implemented user model, then roles and policies names constants. 
After all DbContext with overrided SaveChanges (provides updating LastUpdated field with new date). 
Then added authorization configuration (policies, password requirements and etc).

### Affected Area

AccountsServices.Models
AccountsServices.Infrastructure.Context
AccountsServices.Constants.Auth

### PR Checklist

*Build*

 - [x] Build Succeeded