### PR TITLE
Fix missing roles property in AccountsService DbContext

### DIFF
--- a/src/AccountsService/Infrastructure/Context/AccountsServiceContext.cs
+++ b/src/AccountsService/Infrastructure/Context/AccountsServiceContext.cs
@@ -17,7 +17,7 @@ namespace AccountsService.Infrastructure.Context
         {
             base.OnModelCreating(builder);
 
-            var roles = AccountsRoles.GetRoles();
+            var roles = AccountsRoles.Roles;
 
             builder.Entity<IdentityRole<Guid>>().HasData(roles);
         }


### PR DESCRIPTION
### What

**AccountsService:**

- Replace old method GetRoles with auto-property in AccountRoles class.

### How

Replaced old method with an auto-property

### Affected Area.

AccountsService.Infrastructure.Context

### PR Checklist

*Build*

 - [x] Build Succeeded