### PR TITLE
Add user endpoint for deleting own account and fix authorization

### DIFF
--- a/src/AccountsService/Controllers/DefaultAccountsController.cs
+++ b/src/AccountsService/Controllers/DefaultAccountsController.cs
@@ -1,4 +1,5 @@
-﻿using AccountsService.Constants.Logger;
+﻿using AccountsService.Constants.Auth;
+using AccountsService.Constants.Logger;
 using AccountsService.Models;
 using AccountsService.Services;
 using AccountsService.Utilities;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using System.Security.Claims;
 
 namespace AccountsService.Controllers
 {
@@ -24,6 +26,7 @@ namespace AccountsService.Controllers
         private readonly IMapper _mapper;
         private readonly ILogger<DefaultAccountsController> _logger;
         private readonly IOptions<JwtConfigugartionModel> _jwtConfig;
+        private Guid _userId => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier));
         public DefaultAccountsController(
             IAccountsSvc accountsSvc, 
             IMapper mapper, 
@@ -61,6 +64,19 @@ namespace AccountsService.Controllers
             _logger.LogInformation(LoggingForms.LoggedIn, viewModel.Email);
 
             return Ok(token);
+        }
+
+        [Authorize(Policy = AccountsPolicies.DefaultRights)]
+        [HttpDelete("[action]")]
+        public async Task<IActionResult> DeleteAsync()
+        {
+            _logger.LogInformation(LoggingForms.DeletionAttempt, _userId);
+
+            await _accountsSvc.DeleteAsync(_userId);
+
+            _logger.LogInformation(LoggingForms.UserDeleted, _userId);
+
+            return Ok();
         }
     }
 }

--- a/src/AccountsService/Program.cs
+++ b/src/AccountsService/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -34,9 +35,15 @@ builder.Services.AddIdentity<User, IdentityRole<Guid>>(options =>
 }).AddEntityFrameworkStores<AccountsServiceContext>();
 
 
-builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+builder.Services.AddAuthentication(options => 
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
+})
     .AddJwtBearer(opt =>
     {
+        opt.SaveToken = true;
         opt.TokenValidationParameters = new()
         {
             ValidateAudience = true,
@@ -62,7 +69,34 @@ builder.Services.AddAuthorization(options =>
 builder.Services.AddControllers();
 
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo { Title = "VehicleInformationSystem", Version = "v1" });
+    options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "JWT Authorization header using the Bearer scheme. \r\n\r\n Enter 'Bearer' [space] and then your token in the text input below.\r\n\r\nExample: \"Bearer 1safsfsdfdfd\"",
+    });
+
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            new string[] { }
+        }
+    });
+});
 
 var app = builder.Build();
 

--- a/src/AccountsService/Services/AccountsSvc.cs
+++ b/src/AccountsService/Services/AccountsSvc.cs
@@ -6,8 +6,10 @@ using AccountsService.Utilities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Text;
 
 namespace AccountsService.Services
 {
@@ -38,12 +40,15 @@ namespace AccountsService.Services
 
         public JwtSecurityToken CreateSecurityToken(IOptions<JwtConfigugartionModel> securityConfig, List<Claim> claims)
         {
+            var symSecurityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(securityConfig.Value.Key));
+
             return new(
                 issuer: securityConfig.Value.Issuer,
                 audience: securityConfig.Value.Audience,
                 notBefore: DateTime.UtcNow,
                 claims: claims,
-                expires: DateTime.UtcNow.AddHours(securityConfig.Value.LifetimeHours));
+                expires: DateTime.UtcNow.AddHours(securityConfig.Value.LifetimeHours),
+                signingCredentials: new SigningCredentials(symSecurityKey, SecurityAlgorithms.HmacSha256));
         }
 
         public async Task<string> LoginAsync(string email, string password, IOptions<JwtConfigugartionModel> securityConfig)


### PR DESCRIPTION
### What

User should be able to delete his own account

### How

Fixed the issue when the user could not be authorized properly: added signing credentials while creating token.
Added an endpoint to Default Users controller for user ability to delete his own account.

### Affected Area

AccountsService
AccountsService.Services
AccountsService.Controllers

### PR Checklist

*Build*

 - [x] Build Succeeded