### PR TITLE
Refactor IAccountsService interface

### DIFF
--- a/src/AccountsService/Services/AccountsSvc.cs
+++ b/src/AccountsService/Services/AccountsSvc.cs
@@ -23,7 +23,7 @@ namespace AccountsService.Services
             _logger = logger;
         }
 
-        public List<Claim> GetClaims(User user, IList<string> userRoles)
+        private List<Claim> GetClaims(User user, IList<string> userRoles)
         {
             var claims = new List<Claim>()
             {
@@ -38,7 +38,7 @@ namespace AccountsService.Services
             return claims;
         }
 
-        public JwtSecurityToken CreateSecurityToken(IOptions<JwtConfigugartionModel> securityConfig, List<Claim> claims)
+        private JwtSecurityToken CreateSecurityToken(IOptions<JwtConfigugartionModel> securityConfig, List<Claim> claims)
         {
             var symSecurityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(securityConfig.Value.Key));
 

--- a/src/AccountsService/Services/IAccountsSvc.cs
+++ b/src/AccountsService/Services/IAccountsSvc.cs
@@ -12,7 +12,5 @@ namespace AccountsService.Services
         public Task RegisterAsync(User user, string password);
         public Task DeleteAsync(Guid id);
         public Task<string> LoginAsync(string email, string password, IOptions<JwtConfigugartionModel> securityConfig);
-        protected List<Claim> GetClaims(User user, IList<string> userRoles);
-        protected JwtSecurityToken CreateSecurityToken(IOptions<JwtConfigugartionModel> securityConfig, List<Claim> claims);
     }
 }


### PR DESCRIPTION
### What

Remove GetClaims and CreateSecurityToken definitions.

### How

Removed CreateSecurityToken and GetClaims methods from IAccountsSvc.
Changed signature of that methods in AccountsSvc from public to private.

### Affected Area

AccountsService.Services

### PR Checklist

*Build*

 - [x] Build Succeeded